### PR TITLE
feat: add support for svg defs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "bundle": "vue-cli-service build --target lib --name HexaMaps ./src/index.js",
+    "bundle-watch": "vue-cli-service build --watch --target lib --name HexaMaps ./src/index.js",
     "lint": "vue-cli-service lint"
   },
   "main": "./dist/HexaMaps.umd.min.js",

--- a/src/components/HmMap.js
+++ b/src/components/HmMap.js
@@ -80,9 +80,19 @@ export default function(plugin) {
           mousemove: this.pan,
           mouseup: this.panEnd
         }}, [
+          createElement('defs', {}, 
+            plugin.mapComponents.filter((com) => com.isDef).map((child) => {
+              const mapDefs = child(
+                this.map.config,
+                {inputs: this[child.pluginName + 'In'], outputs: this[child.pluginName + 'Out'], data: this[child.pluginName]},
+                this.map.data
+              )
+              return mapDefs.map(mapDef => createElement(mapDef.component, {props: mapDef.props}))
+            })
+          ),
           createElement('g', {class: 'hm-countries', attrs: {transform: this.transform, stroke: this.map.config.border, fill: this.map.config.land}},
             // MapComponents go first
-            plugin.mapComponents.map(child => {
+            plugin.mapComponents.filter((com) => !com.isDef).map(child => {
               const mapComponents = child(
                 this.map.config,
                 {inputs: this[child.pluginName + 'In'], outputs: this[child.pluginName + 'Out'], data: this[child.pluginName]},


### PR DESCRIPTION
This is useful to add `<defs>` in the SVG. Need to add a attribute "isDef: true" to each component.

Example : https://github.com/Hexastack/hexamaps-addon-lineargradient